### PR TITLE
Feat: Limit player pitch to prevent in-place camera backflips

### DIFF
--- a/client/src/systems/input/look.rs
+++ b/client/src/systems/input/look.rs
@@ -24,7 +24,11 @@ pub fn update_input_look(
     for motion in mouse.iter() {
         player.pitch -= (MOUSE_SENSITIVITY * motion.delta.y * window_scale).to_radians();
         player.yaw -= (MOUSE_SENSITIVITY * motion.delta.x * window_scale).to_radians();
-
+        
+        // Prevent the player from looking too far up or down
+        player.pitch = player.pitch.min(std::f32::consts::FRAC_PI_2);
+        player.pitch = player.pitch.max(-std::f32::consts::FRAC_PI_2);
+        
         transform.rotation = Quat::from_axis_angle(Vec3::Y, player.yaw)
             * Quat::from_axis_angle(Vec3::X, player.pitch);
     }


### PR DESCRIPTION
## Description
- When the user moves the mouse down or up it limits it to known min/max to prevent the camera from inverting which could potentially confuse users.

### Features
- The sky is up
- Ground is down

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

## Issue/Ticket
None